### PR TITLE
Generate Markdown TOC with backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ python -m update_docs.cli --docs docs --toc toc.json
 
 - `--docs`: путь к папке с документацией (по умолчанию: `docs`)
 - `--toc`: путь к JSON-файлу оглавления (по умолчанию: `toc.json`)
+- `--toc-md`: путь к Markdown-версии TOC. Если указан, файл будет создан, а в
+  каждую страницу будет добавлена ссылка "Back to TOC".
 
 ## 🔁 Интеграция с Git pre-commit hook
 
@@ -34,7 +36,7 @@ python -m update_docs.cli --docs docs --toc toc.json
 ```bash
 #!/bin/bash
 echo "🛠 Запуск update-docs перед коммитом..."
-update-docs --docs docs --toc toc.json
+update-docs --docs docs --toc toc.json --toc-md toc.md
 ```
 
 Сделайте его исполняемым:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,3 +23,36 @@ def test_cli_creates_toc(tmp_path):
     data = json.loads(toc_path.read_text())
     assert data[0]["file"] == "index.md"
 
+
+def test_cli_creates_markdown_toc(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.md").write_text("# Title\n")
+    toc_json = tmp_path / "toc.json"
+    toc_md = tmp_path / "toc.md"
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "update_docs.cli",
+            "--docs",
+            str(docs),
+            "--toc",
+            str(toc_json),
+            "--toc-md",
+            str(toc_md),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert toc_md.exists()
+    content = toc_md.read_text()
+    assert "[index.md](index.md)" in content
+    md_content = (docs / "index.md").read_text().splitlines()[0]
+    assert "[Back to TOC]" in md_content
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,8 @@ from update_docs.core import (
     build_toc,
     extract_section,
     update_includes,
+    write_markdown_toc,
+    inject_back_to_toc_links,
 )
 
 
@@ -59,4 +61,25 @@ def test_update_includes(tmp_path):
     content = target.read_text()
     assert "<!-- BEGIN include:src.md#part -->" in content
     assert "content" in content
+
+
+def test_write_markdown_toc(tmp_path):
+    toc = [{"file": "index.md", "headers": []}]
+    path = tmp_path / "toc.md"
+    write_markdown_toc(toc, path)
+    content = path.read_text()
+    assert "[index.md](index.md)" in content
+    assert '<a id="index-md"></a>' in content
+
+
+def test_inject_back_to_toc_links(tmp_path):
+    docs = tmp_path
+    md = docs / "index.md"
+    md.write_text("# Title\n")
+    toc_md = tmp_path / "toc.md"
+    toc_md.write_text("toc")
+    toc = [{"file": "index.md", "headers": []}]
+    inject_back_to_toc_links(docs, toc_md, toc)
+    content = md.read_text().splitlines()[0]
+    assert "[Back to TOC]" in content
 

--- a/update_docs/cli.py
+++ b/update_docs/cli.py
@@ -11,8 +11,11 @@ def main():
     parser.add_argument(
         "--toc", default="toc.json", help="Path to TOC file (output)"
     )
+    parser.add_argument(
+        "--toc-md", help="Path to Markdown TOC file (output)", default=None
+    )
     args = parser.parse_args()
-    update_all(args.docs, args.toc)
+    update_all(args.docs, args.toc, args.toc_md)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- create optional Markdown TOC generation and backlink injection
- expose new `--toc-md` CLI option
- document the feature in README
- test Markdown TOC generation and backlink injection

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641940b9dc8327b400810fa47a4dac